### PR TITLE
Make it possible to specify the rtp and rtcp ports

### DIFF
--- a/README
+++ b/README
@@ -56,6 +56,13 @@ vdr -P 'satip -s <ipaddress>|<model>|<description>;...'
 vdr -P 'satip -s 192.168.0.1|DVBS2-2,DVBT2-2|Octo1'
 vdr -P 'satip -s 192.168.0.1|DVBS2-4|Octo1;192.168.0.2|DVBT2-4|Octo2'
 
+The plugin accepts a "--portrange" (-r) command-line parameter, it can
+be used to manully specify the rtp & rtcp port range. This makes it 
+possible to use the plugin through a NAT (e.g. a docker bridged network)
+You have to ensure that these ports are availiable. 
+Number of ports = startport + (devices*2) -1
+Do not use this feature until you know what you are doing.
+
 SAT>IP satellite positions (aka. signal sources) shall be defined via
 sources.conf. If the source description begins with a number, it's used
 as SAT>IP signal source selection parameter. A special number zero can

--- a/config.c
+++ b/config.c
@@ -17,6 +17,7 @@ cSatipConfig::cSatipConfig(void)
   ciExtensionM(0),
   eitScanM(1),
   useBytesM(1),
+  portRangeM(0),
   detachedModeM(false),
   disableServerQuirksM(false),
   useSingleModelServersM(false)

--- a/config.h
+++ b/config.h
@@ -19,6 +19,7 @@ private:
   unsigned int ciExtensionM;
   unsigned int eitScanM;
   unsigned int useBytesM;
+  unsigned int portRangeM;
   bool detachedModeM;
   bool disableServerQuirksM;
   bool useSingleModelServersM;
@@ -74,6 +75,7 @@ public:
   int GetDisabledSources(unsigned int indexP) const;
   unsigned int GetDisabledFiltersCount(void) const;
   int GetDisabledFilters(unsigned int indexP) const;
+  unsigned int GetPortRange(void) const { return portRangeM; }
 
   void SetOperatingMode(unsigned int operatingModeP) { operatingModeM = operatingModeP; }
   void SetTraceMode(unsigned int modeP) { traceModeM = (modeP & eTraceModeMask); }
@@ -86,6 +88,7 @@ public:
   void SetUseSingleModelServers(bool onOffP) { useSingleModelServersM = onOffP; }
   void SetDisabledSources(unsigned int indexP, int sourceP);
   void SetDisabledFilters(unsigned int indexP, int numberP);
+  void SetPortRange(unsigned int rangeP) { portRangeM = rangeP; }
 };
 
 extern cSatipConfig SatipConfig;

--- a/satip.c
+++ b/satip.c
@@ -87,7 +87,10 @@ const char *cPluginSatip::CommandLineHelp(void)
          "                                define hard-coded SAT>IP server(s)\n"
          "  -D, --detach                  set the detached mode on\n"
          "  -S, --single                  set the single model server mode on\n"
-         "  -n, --noquirks                disable all the server quirks\n";
+         "  -n, --noquirks                disable all the server quirks\n"
+         "  -r, --portrange=<start>       set a range of ports used for the rt[c]p server\n"
+         "                                2 ports per device will be allocated\n"
+         "                                make sure these ports are availiable!\n";
 }
 
 bool cPluginSatip::ProcessArgs(int argc, char *argv[])
@@ -98,6 +101,7 @@ bool cPluginSatip::ProcessArgs(int argc, char *argv[])
     { "devices",  required_argument, NULL, 'd' },
     { "trace",    required_argument, NULL, 't' },
     { "server",   required_argument, NULL, 's' },
+    { "portrange",required_argument, NULL, 'r' },
     { "detach",   no_argument,       NULL, 'D' },
     { "single",   no_argument,       NULL, 'S' },
     { "noquirks", no_argument,       NULL, 'n' },
@@ -106,7 +110,7 @@ bool cPluginSatip::ProcessArgs(int argc, char *argv[])
 
   cString server;
   int c;
-  while ((c = getopt_long(argc, argv, "d:t:s:DSn", long_options, NULL)) != -1) {
+  while ((c = getopt_long(argc, argv, "d:t:s:r:DSn", long_options, NULL)) != -1) {
     switch (c) {
       case 'd':
            deviceCountM = strtol(optarg, NULL, 0);
@@ -125,6 +129,9 @@ bool cPluginSatip::ProcessArgs(int argc, char *argv[])
            break;
       case 'n':
            SatipConfig.SetDisableServerQuirks(true);
+           break;
+      case 'r':
+           SatipConfig.SetPortRange(strtol(optarg, NULL, 0));
            break;
       default:
            return false;

--- a/tuner.c
+++ b/tuner.c
@@ -50,13 +50,20 @@ cSatipTuner::cSatipTuner(cSatipDeviceIf &deviceP, unsigned int packetLenP)
   debug1("%s (, %d) [device %d]", __PRETTY_FUNCTION__, packetLenP, deviceIdM);
 
   // Open sockets
-  int i = 100;
-  while (i-- > 0) {
-        if (rtpM.Open(0) && rtcpM.Open(rtpM.Port() + 1))
-           break;
-        rtpM.Close();
-        rtcpM.Close();
-        }
+  if(SatipConfig.GetPortRange() == 0) {
+    int i = 100;
+    while (i-- > 0) {
+      if (rtpM.Open(0) && rtcpM.Open(rtpM.Port() + 1))
+         break;
+      rtpM.Close();
+      rtcpM.Close();
+      }
+    }
+  else {
+    unsigned int p = SatipConfig.GetPortRange() + (deviceIdM * 2);
+    rtpM.Open(p);
+    rtcpM.Open(p + 1);
+    }
   if ((rtpM.Port() <= 0) || (rtcpM.Port() <= 0)) {
      error("Cannot open required RTP/RTCP ports [device %d]", deviceIdM);
      }


### PR DESCRIPTION
this makes it possible to use the satip through a
NAT (e.g. a docker bridged network)
